### PR TITLE
FAO Publications: Update DOI method

### DIFF
--- a/FAO Publications.js
+++ b/FAO Publications.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2020-05-17 12:27:13"
+	"lastUpdated": "2020-06-10 11:30:50"
 }
 
 /*
@@ -59,12 +59,12 @@ function scrape(doc, url) {
 	if (url.includes('card')) {
 		// attach document card URL and snapshot
 		// TEMP: Disable at least until we have post-JS snapshots
-		/*newItem.attachments.push({
+		/* newItem.attachments.push({
 			url: url,
 			title: 'FAO Document Record Snapshot',
 			mimeType: 'text/html',
 			snapshot: true
-		});*/
+		}); */
 
 		//* ********* Begin fixed-location variables **********
 
@@ -98,10 +98,13 @@ function scrape(doc, url) {
 					newItem.abstractNote = child.textContent;
 				}
 			}
-			// DOI: Some docs contain DOI as the last paragraph in abs field
+			// DOI: Some docs contain DOI as a separate paragraph in abs field
+			// use DOI URL as url when DOI exists
 			var DOILead = 'https://doi.org/';
-			if (abs.textContent.includes(DOILead)) {
-				newItem.DOI = abs.textContent.slice(abs.textContent.indexOf(DOILead) + DOILead.length);
+			if (abs.innerText.includes(DOILead)) {
+				var DOIMatch = abs.innerText.match(/https:\/\/doi\.org\/(.+)/i);
+				newItem.DOI = DOIMatch[1];
+				newItem.url = DOIMatch[0];
 			}
 		}
 		// attach PDF
@@ -111,8 +114,10 @@ function scrape(doc, url) {
 			title: 'Full Text PDF',
 			mimeType: 'application/pdf'
 		});
-		// url
-		newItem.url = url;
+		// url when DOI doesn't exist
+		if (!abs.innerText.includes(DOILead)) {
+			newItem.url = url;
+		}
 		// language: 2 or 3 letters following ISO 639
 		// indicated by the last 1-3 letters in PDF file name (langCode)
 		// One good example is the various language versions of http://www.fao.org/publications/card/en/c/I2801E
@@ -331,6 +336,63 @@ function doWeb(doc, url) {
 var testCases = [
 	{
 		"type": "web",
+		"url": "http://www.fao.org/documents/card/en/c/ca8466en",
+		"defer": true,
+		"items": [
+			{
+				"itemType": "book",
+				"title": "Responding to the impact of the COVID-19 outbreak on food value chains through efficient logistics",
+				"creators": [
+					{
+						"lastName": "FAO",
+						"creatorType": "author",
+						"fieldMode": 1
+					}
+				],
+				"date": "2020",
+				"ISBN": "9789251323717",
+				"abstractNote": "Measures implemented around the world to contain the COVID-19 pandemic have entailed a severe reduction not only in the transportation of goods and services that rely on transport, but also in the migration of labour domestically and internationally. Workers are less available reflecting both disruptions in transportation systems and restrictions to stop the transmission of the disease, within and across borders. \n\nThe Food and Agriculture Organization of the United Nations (FAO) urges countries to maintain functioning food value chains to avoid food shortages, following practices that are being proven to work. This note summarizes some practices that could be useful for governments and the private sector to maintain critical logistical elements in food value chain.\n\nRevised 26 April 2020.\n\nSee the full list of policy briefs related to COVID-19\n\n.",
+				"language": "en",
+				"libraryCatalog": "FAO Publications",
+				"numPages": "4",
+				"place": "Rome, Italy",
+				"publisher": "FAO",
+				"url": "https://doi.org/10.4060/ca8466en",
+				"attachments": [
+					{
+						"title": "FAO Document Record Snapshot",
+						"mimeType": "text/html",
+						"snapshot": true
+					},
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					}
+				],
+				"tags": [
+					{
+						"tag": "Coronavirus"
+					},
+					{
+						"tag": "agrifood sector"
+					},
+					{
+						"tag": "infectious diseases"
+					},
+					{
+						"tag": "logistics"
+					},
+					{
+						"tag": "value chains"
+					}
+				],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
 		"url": "http://www.fao.org/documents/card/en/c/ca8751en/",
 		"defer": true,
 		"items": [
@@ -359,8 +421,13 @@ var testCases = [
 				"publisher": "FAO",
 				"series": "FAO Fisheries and Aquaculture Circular",
 				"seriesNumber": "No. 1207",
-				"url": "http://www.fao.org/documents/card/en/c/ca8751en/",
+				"url": "https://doi.org/10.4060/ca8751en",
 				"attachments": [
+					{
+						"title": "FAO Document Record Snapshot",
+						"mimeType": "text/html",
+						"snapshot": true
+					},
 					{
 						"title": "Full Text PDF",
 						"mimeType": "application/pdf"
@@ -422,6 +489,11 @@ var testCases = [
 				"url": "http://www.fao.org/documents/card/en/c/I9069EN",
 				"attachments": [
 					{
+						"title": "FAO Document Record Snapshot",
+						"mimeType": "text/html",
+						"snapshot": true
+					},
+					{
 						"title": "Full Text PDF",
 						"mimeType": "application/pdf"
 					}
@@ -481,8 +553,13 @@ var testCases = [
 				"place": "Rome, Italy",
 				"publisher": "FAO",
 				"shortTitle": "FAO publications catalogue 2020",
-				"url": "http://www.fao.org/documents/card/en/c/ca7988en/",
+				"url": "https://doi.org/10.4060/ca7988en",
 				"attachments": [
+					{
+						"title": "FAO Document Record Snapshot",
+						"mimeType": "text/html",
+						"snapshot": true
+					},
 					{
 						"title": "Full Text PDF",
 						"mimeType": "application/pdf"
@@ -539,6 +616,11 @@ var testCases = [
 				"seriesNumber": "21",
 				"url": "http://www.fao.org/publications/card/fr/c/77dbd058-8dd4-4295-af77-23f6b28cc683/",
 				"attachments": [
+					{
+						"title": "FAO Document Record Snapshot",
+						"mimeType": "text/html",
+						"snapshot": true
+					},
 					{
 						"title": "Full Text PDF",
 						"mimeType": "application/pdf"
@@ -642,6 +724,11 @@ var testCases = [
 				"url": "http://www.fao.org/publications/card/zh/c/mw246ZH/",
 				"attachments": [
 					{
+						"title": "FAO Document Record Snapshot",
+						"mimeType": "text/html",
+						"snapshot": true
+					},
+					{
 						"title": "Full Text PDF",
 						"mimeType": "application/pdf"
 					}
@@ -732,6 +819,11 @@ var testCases = [
 				"url": "http://www.fao.org/publications/card/en/c/5014f143-be17-4b58-b90e-f1c6bef344a0/",
 				"attachments": [
 					{
+						"title": "FAO Document Record Snapshot",
+						"mimeType": "text/html",
+						"snapshot": true
+					},
+					{
 						"title": "Full Text PDF",
 						"mimeType": "application/pdf"
 					}
@@ -765,12 +857,12 @@ var testCases = [
 				"notes": [],
 				"seeAlso": []
 			}
-		],
-		"defer": true
+		]
 	},
 	{
 		"type": "web",
 		"url": "http://www.fao.org/publications/card/ar/c/c6c2c8d7-3683-53a7-ab58-ce480c65f36c/",
+		"defer": true,
 		"items": [
 			{
 				"itemType": "book",
@@ -791,6 +883,11 @@ var testCases = [
 				"publisher": "FAO",
 				"url": "http://www.fao.org/publications/card/ar/c/c6c2c8d7-3683-53a7-ab58-ce480c65f36c/",
 				"attachments": [
+					{
+						"title": "FAO Document Record Snapshot",
+						"mimeType": "text/html",
+						"snapshot": true
+					},
 					{
 						"title": "Full Text PDF",
 						"mimeType": "application/pdf"
@@ -822,8 +919,7 @@ var testCases = [
 				"notes": [],
 				"seeAlso": []
 			}
-		],
-		"defer": true
+		]
 	}
 ]
 /** END TEST CASES **/


### PR DESCRIPTION
Reupload for https://github.com/zotero/translators/pull/2191

DOI has become standard for new FAO publications.
Method for obtaining the DOI is optimized. Also assign DOI URL as newItem.url when DOI exists.